### PR TITLE
Add feature to run command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,6 @@ jobs:
       - name: "Install package"
         run: pip install .[test]
       - name: "Run tests"
+        env:
+          BELL_MODE: "LOCAL"
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,4 @@ jobs:
       - name: "Install package"
         run: pip install .[test]
       - name: "Run tests"
-        env:
-          BELL_MODE: "LOCAL"
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: "Run tests"
+on: ["push"]
+jobs:
+  Run-tests:
+    runs-on: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: "Install package"
+        run: pip install .[test]
+      - name: "Run tests"
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -7,24 +7,38 @@ A tool to send you alerts from your AWS instances
 Install
 
 ```
-pip install git+https://github.com/MantisAI/bell.git
+pip install git+https://github.com/MantisAI/bell.git@main
 ```
 
-Use in an EC2 instance
+Use bell 🛎  to get alerts that your AWS instance is on
 
 ```
-bell SLACK_WEBHOOK
+bell --webhook-url SLACK_WEBHOOK_URL
 ```
+
+Use bell 🛎  to get alerts about when a command starts, fails or finishes
+
+```
+export SLACK_WEBHOOK_URL=xxx
+
+bell python -c "print('hello')"
+```
+
+Note that you can pass the slack webhook URL either as a command line parameter
+`--webhook-url` or as an environment variable `SLACK_WEBHOOK_URL`
 
 You can read how to setup a slack webbook [here](https://api.slack.com/incoming-webhooks)
 
+
 # Cron
 
-This tool is intended to be used with a scheduler like cron. Here is an example cron
+This tool works well with a scheduler like cron. Here is an example cron
 command which sends an alert every 2 hours
 
 ```
-0 */2 * * * bell WEBHOOK_URL
+SLACK_WEBHOOK_URL=xxx
+
+0 */2 * * * bell
 ```
 
 Note that cron's environment is different to your user or root environment. See troubleshooting
@@ -33,13 +47,12 @@ if you have problems setting up bell to work with cron.
 # CLI
 
 ```
-Usage: bell [OPTIONS] WEBHOOK_URL
+usage: bell [-h] [--webhook-url WEBHOOK_URL]
 
-Arguments:
-  WEBHOOK_URL  [required]
-
-Options:
-  --help                          Show this message and exit.
+optional arguments:
+  -h, --help            show this help message and exit
+  --webhook-url WEBHOOK_URL
+                        incoming slack webhook url
 ```
 
 # Troubleshooting

--- a/bell.py
+++ b/bell.py
@@ -1,21 +1,26 @@
+from socket import timeout
+import urllib.request
 import subprocess
 import argparse
+import json
+import sys
 import os
 
 from loguru import logger
-import requests
 import boto3
 
 
-BELL_MODE = os.environ.get("BELL_MODE")
-
-
 def get_status_message():
-    if BELL_MODE == "LOCAL":
+    try:
+        response = urllib.request.urlopen(
+            "http://169.254.169.254/latest/meta-data/instance-id", timeout=5
+        )
+        instance_id = response.read()
+    except urllib.request.URLError:
+        logger.debug(
+            "Metadata request timed out. You are probably not in an AWS instance."
+        )
         return ":bellhop_bell: local mode"
-
-    response = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
-    instance_id = response.text
 
     ec2 = boto3.client("ec2")
     response = ec2.describe_tags(
@@ -32,40 +37,56 @@ def get_status_message():
     return f":bellhop_bell: {ec2_instance_name} is {status}"
 
 
-def send_slack_message(message):
+def send_slack_message(webhook_url, message):
     logger.debug(f"slack message: {message}")
 
-    if BELL_MODE == "LOCAL":
-        return
+    data = json.dumps({"text": message}).encode("utf-8")
 
-    response = requests.post(webhook_url, json={"text": message})
-    logger.debug(f"slack response code: {response.status_code}")
+    request = urllib.request.Request(webhook_url)
+    request.add_header("Content-Type", "application/json; charset=utf-8")
+    request.add_header("Content-Length", len(data))
+
+    try:
+        response = urllib.request.urlopen(request, data, timeout=5)
+        logger.debug(f"slack response code: {response.getcode()}")
+    except urllib.request.URLError:
+        logger.error(
+            "slack message not sent. probably timeout. this is normal if you are testing or running locally."
+        )
 
 
-def bell(webhook_url, *command_args):
-    if command_args:
-        logger.debug(f"command: {command_args}")
+def bell(webhook_url, *command):
+    if command:
+        logger.debug(f"command: {command}")
         try:
-            send_slack_message("command started")
-            subprocess.run(command_args, check=True)
+            send_slack_message(webhook_url, "command started")
+            subprocess.run(command, check=True)
         except subprocess.CalledProcessError:
             logger.error("command failed")
-            send_slack_message("command failed")
+            send_slack_message(webhook_url, "command failed")
             raise
 
-        send_slack_message("command finished")
+        send_slack_message(webhook_url, "command finished")
     else:
         instance_status = get_status_message()
-        send_slack_message(instance_status)
+        send_slack_message(webhook_url, instance_status)
 
 
 def cli():
     argument_parser = argparse.ArgumentParser()
-    argument_parser.add_argument("--webhook-url", help="incoming slack webhook url")
+    argument_parser.add_argument(
+        "--webhook-url",
+        default=os.environ.get("SLACK_WEBHOOK_URL"),
+        help="incoming slack webhook url",
+    )
 
     args, command_args = argument_parser.parse_known_args()
-    logger.debug(f"args: {args}")
-    logger.debug(f"command_args: {command_args}")
+
+    if not args.webhook_url:
+        print(
+            "You need to pass a value for webhook url either through --webhook-url or as an environment variable SLACK_WEBHOOK_URL"
+        )
+        sys.exit(1)
 
     bell(args.webhook_url, *command_args)
 

--- a/bell.py
+++ b/bell.py
@@ -59,14 +59,21 @@ def bell(webhook_url, *command):
     if command:
         logger.debug(f"command: {command}")
         try:
-            send_slack_message(webhook_url, "command started")
+            send_slack_message(
+                webhook_url,
+                f":bellhop_bell: command `{' '.join(command)}` started :rocket:",
+            )
             subprocess.run(command, check=True)
         except subprocess.CalledProcessError:
             logger.error("command failed")
-            send_slack_message(webhook_url, "command failed")
+            send_slack_message(
+                webhook_url, f":bellhop_bell: command `{' '.join(command)}` failed :x:"
+            )
             raise
 
-        send_slack_message(webhook_url, "command finished")
+        send_slack_message(
+            webhook_url, f":bellhop_bell: command `{' '.join(command)}` finished :boom:"
+        )
     else:
         instance_status = get_status_message()
         send_slack_message(webhook_url, instance_status)

--- a/bell.py
+++ b/bell.py
@@ -7,7 +7,8 @@ import requests
 import boto3
 
 
-BELL_MODE = os.environ["BELL_MODE"]
+BELL_MODE = os.environ.get("BELL_MODE")
+
 
 def get_status_message():
     if BELL_MODE == "LOCAL":
@@ -37,9 +38,7 @@ def send_slack_message(message):
     if BELL_MODE == "LOCAL":
         return
 
-    response = requests.post(
-        webhook_url, json={"text": message}
-    )
+    response = requests.post(webhook_url, json={"text": message})
     logger.debug(f"slack response code: {response.status_code}")
 
 

--- a/bell.py
+++ b/bell.py
@@ -1,14 +1,18 @@
+import subprocess
+import argparse
+import os
+
 from loguru import logger
 import requests
-import typer
 import boto3
 
 
-app = typer.Typer()
+BELL_MODE = os.environ["BELL_MODE"]
 
+def get_status_message():
+    if BELL_MODE == "LOCAL":
+        return ":bellhop_bell: local mode"
 
-@app.command()
-def bell(webhook_url):
     response = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
     instance_id = response.text
 
@@ -24,12 +28,48 @@ def bell(webhook_url):
     response = ec2.describe_instance_status(InstanceIds=[instance_id])
     status = response["InstanceStatuses"][0]["InstanceState"]["Name"]
     logger.debug(f"ec2 instance status: {status}")
+    return f":bellhop_bell: {ec2_instance_name} is {status}"
+
+
+def send_slack_message(message):
+    logger.debug(f"slack message: {message}")
+
+    if BELL_MODE == "LOCAL":
+        return
 
     response = requests.post(
-        webhook_url, json={"text": f":bellhop_bell: {ec2_instance_name} is {status}"}
+        webhook_url, json={"text": message}
     )
     logger.debug(f"slack response code: {response.status_code}")
 
 
+def bell(webhook_url, *command_args):
+    if command_args:
+        logger.debug(f"command: {command_args}")
+        try:
+            send_slack_message("command started")
+            subprocess.run(command_args, check=True)
+        except subprocess.CalledProcessError:
+            logger.error("command failed")
+            send_slack_message("command failed")
+            raise
+
+        send_slack_message("command finished")
+    else:
+        instance_status = get_status_message()
+        send_slack_message(instance_status)
+
+
+def cli():
+    argument_parser = argparse.ArgumentParser()
+    argument_parser.add_argument("--webhook-url", help="incoming slack webhook url")
+
+    args, command_args = argument_parser.parse_known_args()
+    logger.debug(f"args: {args}")
+    logger.debug(f"command_args: {command_args}")
+
+    bell(args.webhook_url, *command_args)
+
+
 if __name__ == "__main__":
-    app()
+    cli()

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,13 @@ classifiers =
 install_requires =
     boto3
     requests
-    typer
     loguru
 python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =
-    bell = bell:app
+    bell = bell:cli
+
+[options.extras_require]
+test =
+    pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
 [options]
 install_requires =
     boto3
-    requests
     loguru
 python_requires = >=3.6
 

--- a/tests/test_bell.py
+++ b/tests/test_bell.py
@@ -5,16 +5,21 @@ import pytest
 from bell import bell
 
 
-def test_bell():
-    bell("slack webhook url")
+@pytest.fixture
+def slack_webhook_url():
+    return "http://www.slack.com"
 
 
-def test_bell_command():
+def test_bell(slack_webhook_url):
+    bell(slack_webhook_url)
+
+
+def test_bell_command(slack_webhook_url):
     command_args = "python -c \"print('hello')\"".split()
-    bell("slack webhook url", *command_args)
+    bell(slack_webhook_url, *command_args)
 
 
-def test_bell_bad_command():
+def test_bell_bad_command(slack_webhook_url):
     command_args = """ python -c "print('hello' """.split()
     with pytest.raises(subprocess.CalledProcessError):
-        bell("slack webhook url", *command_args)
+        bell(slack_webhook_url, *command_args)

--- a/tests/test_bell.py
+++ b/tests/test_bell.py
@@ -1,0 +1,18 @@
+import subprocess
+
+import pytest
+
+from bell import bell
+
+
+def test_bell():
+    bell("slack webhook url")
+
+def test_bell_command():
+    command_args = "python -c \"print('hello')\"".split()
+    bell("slack webhook url", *command_args)
+
+def test_bell_bad_command():
+    command_args = """ python -c "print('hello' """.split()
+    with pytest.raises(subprocess.CalledProcessError):
+        bell("slack webhook url", *command_args)

--- a/tests/test_bell.py
+++ b/tests/test_bell.py
@@ -8,9 +8,11 @@ from bell import bell
 def test_bell():
     bell("slack webhook url")
 
+
 def test_bell_command():
     command_args = "python -c \"print('hello')\"".split()
     bell("slack webhook url", *command_args)
+
 
 def test_bell_bad_command():
     command_args = """ python -c "print('hello' """.split()


### PR DESCRIPTION
This PR adds the ability to prefix a command you want to run with bell in order to get a slack alert about when a command starts, end or fails. For example `bell dvc repro`.

start command message: 🛎️  command `dvc repro` started 🚀 
fail command message: 🛎️  command `dvc repro` failed ❌ 
finish command message: 🛎️  command `dvc repro` finished 💥 

At the same time though this PR does the following

- remove requests as a dependency and uses `urllib` to reduce dependencies
- remove typer as a dependency and uses `argparse` to reduce dependencies
- adds tests and a GitHub action for tests