### PR TITLE
Reduce bell dependencies to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ optional arguments:
 
 # Troubleshooting
 
+## Logs
+
+By default bell sets the logging level at INFO. For debugging purposes, it is more helpful
+to set it at DEBUG. You can do that via the environment variable `LOGGING_LEVEL` by running
+```
+export LOGGING_LEVEL=DEBUG
+```
+
 ## Bell works when run manually but not through cron
 
 In order for cron to work it needs to have access to both bell, python packages and AWS

--- a/bell.py
+++ b/bell.py
@@ -8,7 +8,8 @@ import sys
 import os
 
 logging.basicConfig(
-    format="%(asctime)s | %(levelname)s | %(funcName)20s:%(lineno)s - %(message)s"
+    format="%(asctime)s | %(levelname)s | %(funcName)20s:%(lineno)s - %(message)s",
+    level=os.environ.get("LOGGING_LEVEL", logging.INFO),
 )
 logger = logging.getLogger(__name__)
 

--- a/bell.py
+++ b/bell.py
@@ -18,12 +18,12 @@ def get_status_message():
         response = urllib.request.urlopen(
             "http://169.254.169.254/latest/meta-data/instance-id", timeout=5
         )
-        instance_id = response.read()
+        instance_id = response.read().decode("utf-8")
 
         response = urllib.request.urlopen(
             "http://169.254.169.254/latest/meta-data/public-hostname", timeout=5
         )
-        public_hostname = response.read()
+        public_hostname = response.read().decode("utf-8")
     except urllib.request.URLError:
         logger.debug(
             "Metadata request timed out. You are probably not in an AWS instance."

--- a/bell.py
+++ b/bell.py
@@ -1,13 +1,16 @@
 from socket import timeout
 import urllib.request
 import subprocess
+import logging
 import argparse
 import json
 import sys
 import os
 
-from loguru import logger
-import boto3
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s | %(funcName)20s:%(lineno)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 
 def get_status_message():
@@ -16,11 +19,21 @@ def get_status_message():
             "http://169.254.169.254/latest/meta-data/instance-id", timeout=5
         )
         instance_id = response.read()
+
+        response = urllib.request.urlopen(
+            "http://169.254.169.254/latest/meta-data/public-hostname", timeout=5
+        )
+        public_hostname = response.read()
     except urllib.request.URLError:
         logger.debug(
             "Metadata request timed out. You are probably not in an AWS instance."
         )
         return ":bellhop_bell: local mode"
+
+    try:
+        import boto3
+    except ImportError:
+        return f":bellhop_bell: {public_hostname} is running"
 
     ec2 = boto3.client("ec2")
     response = ec2.describe_tags(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bell
-version = 0.1.0
+version = 0.1.2
 author = Nick Sorros
 author_email = nick@mantisnlp.com
 description = A tool to alert us about AWS instances
@@ -15,9 +15,6 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-install_requires =
-    boto3
-    loguru
 python_requires = >=3.6
 
 [options.entry_points]
@@ -27,3 +24,5 @@ console_scripts =
 [options.extras_require]
 test =
     pytest
+aws =
+    boto3


### PR DESCRIPTION
This PR makes bell a zero dependency package by:

- removing loguru and using standard logger
- making boto an extra

On the last point, if the user does not install the `aws`
extra then the message only contains the public hostname
as an identifier and defaults to running.
